### PR TITLE
Platformio config

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@^3.5.0
 board = esp32dev
 framework = arduino
 lib_ldf_mode = chain


### PR DESCRIPTION
The project won't build using the latest espressif platform (4.2.0). I had to manually install version 3.5.0 to build.

For future reference, the error I got was: `i2c_t does not name a type`.